### PR TITLE
Introduce a new property to skip security configurations.

### DIFF
--- a/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/bean/SSOAgentConfig.java
+++ b/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/bean/SSOAgentConfig.java
@@ -72,6 +72,7 @@ public class SSOAgentConfig {
     private Set<String> skipURIs = new HashSet<String>();
     private String indexPage;
     private String errorPage;
+    private Boolean skipTLS = false;
 
     private Map<String, String[]> queryParams = new HashMap<String, String[]>();
 
@@ -144,6 +145,16 @@ public class SSOAgentConfig {
     public void setErrorPage(String errorPage) {
 
         this.errorPage = errorPage;
+    }
+
+    public Boolean getSkipTLS() {
+
+        return skipTLS;
+    }
+
+    public void setSkipTLS(Boolean skipTLS) {
+
+        this.skipTLS = skipTLS;
     }
 
     public Map<String, String[]> getQueryParams() {
@@ -336,6 +347,11 @@ public class SSOAgentConfig {
             skipURIs.add(errorPage);
         } else {
             setErrorPage(indexPage);
+        }
+
+        if (StringUtils.isNotBlank(properties.getProperty(SSOAgentConstants.SSOAgentConfig.SKIP_TLS))) {
+            setSkipTLS(Boolean.parseBoolean(
+                    properties.getProperty(SSOAgentConstants.SSOAgentConfig.SKIP_TLS)));
         }
 
         String queryParamsString = properties.getProperty(SSOAgentConstants.SSOAgentConfig.QUERY_PARAMS);

--- a/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/util/SSOAgentConstants.java
+++ b/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/util/SSOAgentConstants.java
@@ -61,6 +61,7 @@ public class SSOAgentConstants {
         public static final String PASSWORD_FILEPATH = "/conf/password_temp.txt";
         public static final String INDEX_PAGE = "IndexPage";
         public static final String ERROR_PAGE = "ErrorPage";
+        public static final String SKIP_TLS = "SkipTLS";
 
         private SSOAgentConfig() {
 


### PR DESCRIPTION
### Proposed changes in this pull request

Introduce a new property called `skipKeystoreConfigs` to explicitly skip the key store security configurations.
By default, this value will be set to false.

Related to https://github.com/asgardeo/asgardeo-tomcat-saml-agent/issues/40.
Related PR: https://github.com/asgardeo/asgardeo-tomcat-saml-agent/pull/39
### When should this PR be merged

ASAP

