### PR TITLE
Default request signing configurations to "False" if keystore configurations are not defined. 

### DIFF
--- a/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/bean/SSOAgentConfig.java
+++ b/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/bean/SSOAgentConfig.java
@@ -463,11 +463,11 @@ public class SSOAgentConfig {
         saml2.enableArtifactResolveSigning = StringUtils.equals(
                 properties.getProperty(SSOAgentConstants.SSOAgentConfig.SAML2.ENABLE_ARTIFACT_RESOLVE_SIGNING), "true");
 
-        if (StringUtils.isNotBlank(properties.getProperty("KeyStore"))) {
+        if (StringUtils.isNotBlank(properties.getProperty(SSOAgentConstants.KEYSTORE))) {
             try {
-                keyStoreStream = new FileInputStream(properties.getProperty("KeyStore"));
+                keyStoreStream = new FileInputStream(properties.getProperty(SSOAgentConstants.KEYSTORE));
             } catch (FileNotFoundException e) {
-                throw new SSOAgentException("Cannot find file " + properties.getProperty("KeyStore"), e);
+                throw new SSOAgentException("Cannot find file " + properties.getProperty(SSOAgentConstants.KEYSTORE), e);
             }
         }
         keyStorePassword = getKeystoreConfig(SSOAgentConstants.KEY_STORE_PASSWORD, properties);

--- a/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/bean/SSOAgentConfig.java
+++ b/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/bean/SSOAgentConfig.java
@@ -72,7 +72,6 @@ public class SSOAgentConfig {
     private Set<String> skipURIs = new HashSet<String>();
     private String indexPage;
     private String errorPage;
-    private Boolean skipTLS = false;
 
     private Map<String, String[]> queryParams = new HashMap<String, String[]>();
 
@@ -145,16 +144,6 @@ public class SSOAgentConfig {
     public void setErrorPage(String errorPage) {
 
         this.errorPage = errorPage;
-    }
-
-    public Boolean getSkipTLS() {
-
-        return skipTLS;
-    }
-
-    public void setSkipTLS(Boolean skipTLS) {
-
-        this.skipTLS = skipTLS;
     }
 
     public Map<String, String[]> getQueryParams() {
@@ -347,11 +336,6 @@ public class SSOAgentConfig {
             skipURIs.add(errorPage);
         } else {
             setErrorPage(indexPage);
-        }
-
-        if (StringUtils.isNotBlank(properties.getProperty(SSOAgentConstants.SSOAgentConfig.SKIP_TLS))) {
-            setSkipTLS(Boolean.parseBoolean(
-                    properties.getProperty(SSOAgentConstants.SSOAgentConfig.SKIP_TLS)));
         }
 
         String queryParamsString = properties.getProperty(SSOAgentConstants.SSOAgentConfig.QUERY_PARAMS);

--- a/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/bean/SSOAgentConfig.java
+++ b/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/bean/SSOAgentConfig.java
@@ -72,7 +72,7 @@ public class SSOAgentConfig {
     private Set<String> skipURIs = new HashSet<String>();
     private String indexPage;
     private String errorPage;
-    private boolean skipKeystoreConfigs = false;
+    private boolean skipKeystoreConfigs;
 
     private Map<String, String[]> queryParams = new HashMap<String, String[]>();
 
@@ -377,9 +377,8 @@ public class SSOAgentConfig {
         saml2.attributeConsumingServiceIndex = properties.getProperty(
                 SSOAgentConstants.SSOAgentConfig.SAML2.ATTRIBUTE_CONSUMING_SERVICE_INDEX);
 
-        String isSLOEnabledString = properties.getProperty(
-                SSOAgentConstants.SSOAgentConfig.SAML2.ENABLE_SLO);
-        if (isSLOEnabledString != null) {
+        String isSLOEnabledString = properties.getProperty(SSOAgentConstants.SSOAgentConfig.SAML2.ENABLE_SLO);
+        if (StringUtils.isNotBlank(isSLOEnabledString)) {
             saml2.isSLOEnabled = Boolean.parseBoolean(isSLOEnabledString);
         } else {
             LOGGER.info("\'" + SSOAgentConstants.SSOAgentConfig.SAML2.ENABLE_SLO +
@@ -388,9 +387,9 @@ public class SSOAgentConfig {
         }
         saml2.sloURL = properties.getProperty(SSOAgentConstants.SSOAgentConfig.SAML2.SLO_URL);
 
-        String isAssertionSignedString = properties.getProperty(
-                SSOAgentConstants.SSOAgentConfig.SAML2.ENABLE_ASSERTION_SIGNING);
-        if (isAssertionSignedString != null && !skipKeystoreConfigs) {
+        String isAssertionSignedString =
+                properties.getProperty(SSOAgentConstants.SSOAgentConfig.SAML2.ENABLE_ASSERTION_SIGNING);
+        if (StringUtils.isNotBlank(isAssertionSignedString) && !skipKeystoreConfigs) {
             saml2.isAssertionSigned = Boolean.parseBoolean(isAssertionSignedString);
         } else {
             LOGGER.log(Level.WARNING, SSOAgentConstants.SSOAgentConfig.SAML2.ENABLE_ASSERTION_SIGNING +
@@ -398,9 +397,9 @@ public class SSOAgentConfig {
             saml2.isAssertionSigned = false;
         }
 
-        String isAssertionEncryptedString = properties.getProperty(
-                SSOAgentConstants.SSOAgentConfig.SAML2.ENABLE_ASSERTION_ENCRYPTION);
-        if (isAssertionEncryptedString != null && !skipKeystoreConfigs) {
+        String isAssertionEncryptedString =
+                properties.getProperty(SSOAgentConstants.SSOAgentConfig.SAML2.ENABLE_ASSERTION_ENCRYPTION);
+        if (StringUtils.isNotBlank(isAssertionEncryptedString) && !skipKeystoreConfigs) {
             saml2.isAssertionEncrypted = Boolean.parseBoolean(isAssertionEncryptedString);
         } else {
             LOGGER.log(Level.WARNING, SSOAgentConstants.SSOAgentConfig.SAML2.ENABLE_ASSERTION_ENCRYPTION +
@@ -408,9 +407,9 @@ public class SSOAgentConfig {
             saml2.isAssertionEncrypted = false;
         }
 
-        String isResponseSignedString = properties.getProperty(
-                SSOAgentConstants.SSOAgentConfig.SAML2.ENABLE_RESPONSE_SIGNING);
-        if (isResponseSignedString != null && !skipKeystoreConfigs) {
+        String isResponseSignedString =
+                properties.getProperty(SSOAgentConstants.SSOAgentConfig.SAML2.ENABLE_RESPONSE_SIGNING);
+        if (StringUtils.isNotBlank(isResponseSignedString) && !skipKeystoreConfigs) {
             saml2.isResponseSigned = Boolean.parseBoolean(isResponseSignedString);
         } else {
             LOGGER.log(Level.WARNING, SSOAgentConstants.SSOAgentConfig.SAML2.ENABLE_RESPONSE_SIGNING +
@@ -421,7 +420,7 @@ public class SSOAgentConfig {
         if (saml2.isResponseSigned() || saml2.isAssertionSigned()) {
             String signatureValidatorImplClass = properties.getProperty(
                     SSOAgentConstants.SSOAgentConfig.SAML2.SIGNATURE_VALIDATOR);
-            if (signatureValidatorImplClass != null) {
+            if (StringUtils.isNotBlank(signatureValidatorImplClass)) {
                 saml2.signatureValidatorImplClass = signatureValidatorImplClass;
             } else {
                 LOGGER.log(Level.FINE, SSOAgentConstants.SSOAgentConfig.SAML2.SIGNATURE_VALIDATOR +
@@ -429,9 +428,9 @@ public class SSOAgentConfig {
             }
         }
 
-        String isRequestSignedString = properties.getProperty(
-                SSOAgentConstants.SSOAgentConfig.SAML2.ENABLE_REQUEST_SIGNING);
-        if (isRequestSignedString != null && !skipKeystoreConfigs) {
+        String isRequestSignedString =
+                properties.getProperty(SSOAgentConstants.SSOAgentConfig.SAML2.ENABLE_REQUEST_SIGNING);
+        if (StringUtils.isNotBlank(isRequestSignedString) && !skipKeystoreConfigs) {
             saml2.isRequestSigned = Boolean.parseBoolean(isRequestSignedString);
         } else {
             LOGGER.log(Level.WARNING, SSOAgentConstants.SSOAgentConfig.SAML2.ENABLE_REQUEST_SIGNING +
@@ -439,9 +438,8 @@ public class SSOAgentConfig {
             saml2.isRequestSigned = false;
         }
 
-        String isPassiveAuthnString = properties.getProperty(
-                SSOAgentConstants.SSOAgentConfig.SAML2.IS_PASSIVE_AUTHN);
-        if (isPassiveAuthnString != null) {
+        String isPassiveAuthnString = properties.getProperty(SSOAgentConstants.SSOAgentConfig.SAML2.IS_PASSIVE_AUTHN);
+        if (StringUtils.isNotBlank(isPassiveAuthnString)) {
             saml2.isPassiveAuthn = Boolean.parseBoolean(isPassiveAuthnString);
         } else {
             LOGGER.log(Level.FINE, "\'" + SSOAgentConstants.SSOAgentConfig.SAML2.IS_PASSIVE_AUTHN +
@@ -449,9 +447,8 @@ public class SSOAgentConfig {
             saml2.isPassiveAuthn = false;
         }
 
-        String isForceAuthnString = properties.getProperty(
-                SSOAgentConstants.SSOAgentConfig.SAML2.IS_FORCE_AUTHN);
-        if (isForceAuthnString != null) {
+        String isForceAuthnString = properties.getProperty(SSOAgentConstants.SSOAgentConfig.SAML2.IS_FORCE_AUTHN);
+        if (StringUtils.isNotBlank(isForceAuthnString)) {
             saml2.isForceAuthn = Boolean.parseBoolean(isForceAuthnString);
         } else {
             LOGGER.log(Level.FINE, "\'" + SSOAgentConstants.SSOAgentConfig.SAML2.IS_FORCE_AUTHN +
@@ -466,7 +463,7 @@ public class SSOAgentConfig {
         saml2.enableArtifactResolveSigning = StringUtils.equals(
                 properties.getProperty(SSOAgentConstants.SSOAgentConfig.SAML2.ENABLE_ARTIFACT_RESOLVE_SIGNING), "true");
 
-        if (properties.getProperty("KeyStore") != null) {
+        if (StringUtils.isNotBlank(properties.getProperty("KeyStore"))) {
             try {
                 keyStoreStream = new FileInputStream(properties.getProperty("KeyStore"));
             } catch (FileNotFoundException e) {
@@ -570,7 +567,7 @@ public class SSOAgentConfig {
     private KeyStore readKeyStore(InputStream is, String storePassword) throws
             SSOAgentException {
 
-        if (storePassword == null) {
+        if (StringUtils.isBlank(storePassword)) {
             throw new SSOAgentException(
                     "KeyStore password can not be null");
         }
@@ -657,7 +654,7 @@ public class SSOAgentConfig {
 
     private String getKeystoreConfig(String property, Properties properties) {
 
-        if(StringUtils.isNotBlank(properties.getProperty(property))) {
+        if (StringUtils.isNotBlank(properties.getProperty(property))) {
             return properties.getProperty(property);
         }
         skipKeystoreConfigs = true;

--- a/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/util/SSOAgentConstants.java
+++ b/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/util/SSOAgentConstants.java
@@ -25,6 +25,7 @@ public class SSOAgentConstants {
     public static final String IDP_PUBLIC_CERT = "IdPPublicCert";
     public static final String PRIVATE_KEY_ALIAS = "PrivateKeyAlias";
     public static final String PRIVATE_KEY_PASSWORD = "PrivateKeyPassword";
+    public static final String KEYSTORE = "KeyStore";
 
     public static final String LOGGER_NAME = "org.wso2.carbon.identity.sso.agent";
 

--- a/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/util/SSOAgentConstants.java
+++ b/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/util/SSOAgentConstants.java
@@ -61,7 +61,6 @@ public class SSOAgentConstants {
         public static final String PASSWORD_FILEPATH = "/conf/password_temp.txt";
         public static final String INDEX_PAGE = "IndexPage";
         public static final String ERROR_PAGE = "ErrorPage";
-        public static final String SKIP_TLS = "SkipTLS";
 
         private SSOAgentConfig() {
 


### PR DESCRIPTION
### Proposed changes in this pull request

Revert "Introduce a new property to skip security configurations."
Set request signing, response signing related configurations to False by default if keystore related configs are not included.

Improvement over https://github.com/asgardeo/asgardeo-java-saml-sdk/pull/15.

Related Issues: https://github.com/asgardeo/asgardeo-tomcat-saml-agent/issues/40
