### PR TITLE
Change the priority order of loading the IDP certifcate from the configuration

### DIFF
--- a/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/security/SSOAgentX509KeyStoreCredential.java
+++ b/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/security/SSOAgentX509KeyStoreCredential.java
@@ -101,11 +101,11 @@ public class SSOAgentX509KeyStoreCredential implements SSOAgentX509Credential {
             throws SSOAgentException {
 
         try {
-            if (StringUtils.isNotEmpty(publicCertAlias)) {
-                entityCertificate = (X509Certificate) keyStore.getCertificate(publicCertAlias);
-            } else if (StringUtils.isNotEmpty(publicCertEncoded)) {
+            if (StringUtils.isNotEmpty(publicCertEncoded)) {
                 entityCertificate = inferPublicCertFromEncodedString(publicCertEncoded);
-            }
+            } else if (StringUtils.isNotEmpty(publicCertAlias)) {
+                entityCertificate = (X509Certificate) keyStore.getCertificate(publicCertAlias);
+            } 
         } catch (KeyStoreException e) {
             throw new SSOAgentException(
                     "Error occurred while retrieving public certificate for alias " +


### PR DESCRIPTION
When both of the following entries are configured
```
# Pem content of the IDP public certificate
IdPPublicCert=

# Alias of the IdP's public certificate
#IdPPublicCertAlias=wso2carbon
```
IdPPublicCertAlias get the prominence according to the current logic in the SAML agent, hence the default cert with wso2carbon alias is loaded as the IDP certificate.