### PR TITLE
Support for storing multiple InResponseTo IDs in the http session

### DIFF
--- a/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/SAML2SSOManager.java
+++ b/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/SAML2SSOManager.java
@@ -377,23 +377,37 @@ public class SAML2SSOManager {
     private void validateInResponseTo(StatusResponseType samlResponse, HttpSession session) throws SSOAgentException {
 
         String inResponseToValue = samlResponse.getInResponseTo();
+        if (session == null) {
+            throw new InvalidSessionException("Session is expired or user already logged out.");
+        }
         if (StringUtils.isNotBlank(inResponseToValue)) {
-            if (session != null && session.getAttribute(SSOAgentConstants.SAML2SSO.ID_ATTRIB_NAME) != null) {
-                String requestId = (String) session.getAttribute(SSOAgentConstants.SAML2SSO.ID_ATTRIB_NAME);
-                session.removeAttribute(SSOAgentConstants.SAML2SSO.ID_ATTRIB_NAME);
-                if (requestId.equals(inResponseToValue)) {
-                    LOGGER.log(Level.FINE, "InResponseTo Validation successful.");
+            if (session.getAttribute(SSOAgentConstants.SAML2SSO.ID_ATTRIB_LIST_NAME) != null) {
+                ArrayList<String> requestIds =
+                        (ArrayList<String>) session.getAttribute(SSOAgentConstants.SAML2SSO.ID_ATTRIB_LIST_NAME);
+                if (requestIds.contains(inResponseToValue)) {
+                    requestIds.remove(inResponseToValue);
                     return;
                 }
             }
             log.fatal(String.format("Validation failed for InResponseTo ID: %s", inResponseToValue));
-            throw new SSOAgentException("ID validation failed.");
+            throw new SSOAgentException("Invalid or already used \"InResponseTo\" value found in the SAML response.");
         }
     }
 
     private void setIDtoSession(HttpSession httpSession, String saml2RequestId) {
 
-        httpSession.setAttribute(SSOAgentConstants.SAML2SSO.ID_ATTRIB_NAME, saml2RequestId);
+        if (httpSession.getAttribute(SSOAgentConstants.SAML2SSO.ID_ATTRIB_LIST_NAME) != null) {
+            ArrayList<String> samlRequestIDs =
+                    (ArrayList<String>) httpSession.getAttribute(SSOAgentConstants.SAML2SSO.ID_ATTRIB_LIST_NAME);
+            if (!samlRequestIDs.contains(saml2RequestId)) {
+                samlRequestIDs.add(saml2RequestId);
+                httpSession.setAttribute(SSOAgentConstants.SAML2SSO.ID_ATTRIB_LIST_NAME, samlRequestIDs);
+            }
+        } else {
+            ArrayList<String> samlRequestIDs = new ArrayList<>();
+            samlRequestIDs.add(saml2RequestId);
+            httpSession.setAttribute(SSOAgentConstants.SAML2SSO.ID_ATTRIB_LIST_NAME, samlRequestIDs);
+        }
     }
 
     /**

--- a/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/SAML2SSOManager.java
+++ b/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/SAML2SSOManager.java
@@ -396,15 +396,14 @@ public class SAML2SSOManager {
 
     private void setIDtoSession(HttpSession httpSession, String saml2RequestId) {
 
+        ArrayList<String> samlRequestIDs;
         if (httpSession.getAttribute(SSOAgentConstants.SAML2SSO.ID_ATTRIB_LIST_NAME) != null) {
-            ArrayList<String> samlRequestIDs =
+            samlRequestIDs =
                     (ArrayList<String>) httpSession.getAttribute(SSOAgentConstants.SAML2SSO.ID_ATTRIB_LIST_NAME);
-            if (!samlRequestIDs.contains(saml2RequestId)) {
-                samlRequestIDs.add(saml2RequestId);
-                httpSession.setAttribute(SSOAgentConstants.SAML2SSO.ID_ATTRIB_LIST_NAME, samlRequestIDs);
-            }
         } else {
-            ArrayList<String> samlRequestIDs = new ArrayList<>();
+            samlRequestIDs = new ArrayList<>();
+        }
+        if (!samlRequestIDs.contains(saml2RequestId)) {
             samlRequestIDs.add(saml2RequestId);
             httpSession.setAttribute(SSOAgentConstants.SAML2SSO.ID_ATTRIB_LIST_NAME, samlRequestIDs);
         }

--- a/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/util/SSOAgentConstants.java
+++ b/io.asgardeo.java.saml.sdk/src/main/java/io/asgardeo/java/saml/sdk/util/SSOAgentConstants.java
@@ -48,7 +48,7 @@ public class SSOAgentConstants {
         public static final String HTTP_POST_PARAM_SAML2_RESP = "SAMLResponse";
         public static final String SAML2_ARTIFACT_RESP = "SAMLart";
         public static final String SUCCESS_CODE = "urn:oasis:names:tc:SAML:2.0:status:Success";
-        public static final String ID_ATTRIB_NAME = "SAML2RequestID";
+        public static final String ID_ATTRIB_LIST_NAME = "SAML2RequestIDs";
         private SAML2SSO() {
 
         }


### PR DESCRIPTION
### Proposed changes in this pull request

This PR introduces the following changes.
- Fix ID validation failures that occur intermittently, and when the browser is refreshed after login into the sample app.
- Fix the ID validation failure error message to give the actual reason for the failure.